### PR TITLE
Correct casing on script strategy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ import { GoogleAnalytics } from "nextjs-google-analytics";
 const App = ({ Component, pageProps }) => {
   return (
     <>
-      <GoogleAnalytics strategy="lazyOnLoad" />
+      <GoogleAnalytics strategy="lazyOnload" />
       <Component {...pageProps} />
     </>
   );


### PR DESCRIPTION
[`next/script`](https://nextjs.org/docs/basic-features/script) uses `lazyOnload` rather than `lazyOnLoad`.