### PR TITLE
Add event handler for hashChangeComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ export function reportWebVitals({
   );
 }
 const App = ({ Component, pageProps }) => {
-  usePageViews(gaMeasurementId);
+  usePageViews({ gaMeasurementId });
 
   return (
     <>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,2 @@
 export { usePagesViews } from "./usePagesViews";
-export { usePageViews } from "./usePageViews";
+export { usePageViews, UsePageViewsOptions } from "./usePageViews";

--- a/src/hooks/usePageViews.ts
+++ b/src/hooks/usePageViews.ts
@@ -2,12 +2,15 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { pageView } from "../interactions";
 
-export interface usePageViewsOptions {
+export interface UsePageViewsOptions {
   gaMeasurementId?: string;
-  enableHashChange?: boolean;
+  ignoreHashChange?: boolean;
 }
 
-export function usePageViews({ gaMeasurementId, enableHashChange }: usePageViewsOptions = {}): void {
+export function usePageViews({
+  gaMeasurementId,
+  ignoreHashChange,
+}: UsePageViewsOptions = {}): void {
   const router = useRouter();
 
   useEffect(() => {
@@ -19,17 +22,17 @@ export function usePageViews({ gaMeasurementId, enableHashChange }: usePageViews
     };
 
     router.events.on("routeChangeComplete", handleRouteChange);
-    
-    if (enableHashChange) {
-      router.events.on('hashChangeComplete', handleRouteChange);
+
+    if (!ignoreHashChange) {
+      router.events.on("hashChangeComplete", handleRouteChange);
     }
 
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);
 
-      if (enableHashChange) {
-        router.events.off('hashChangeComplete', handleRouteChange);
+      if (!ignoreHashChange) {
+        router.events.off("hashChangeComplete", handleRouteChange);
       }
     };
-  }, [router.events, gaMeasurementId, enableHashChange]);
+  }, [router.events, gaMeasurementId, ignoreHashChange]);
 }

--- a/src/hooks/usePageViews.ts
+++ b/src/hooks/usePageViews.ts
@@ -14,9 +14,11 @@ export function usePageViews(gaMeasurementId?: string): void {
     };
 
     router.events.on("routeChangeComplete", handleRouteChange);
+    router.events.on('hashChangeComplete', handleRouteChange);
 
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);
+      router.events.off('hashChangeComplete', handleRouteChange);
     };
   }, [router.events]);
 }

--- a/src/hooks/usePageViews.ts
+++ b/src/hooks/usePageViews.ts
@@ -2,12 +2,12 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { pageView } from "../interactions";
 
-interface usePageViewsOptions {
+export interface usePageViewsOptions {
   gaMeasurementId?: string;
   enableHashChange?: boolean;
 }
 
-export function usePageViews({ gaMeasurementId, enableHashChange }: usePageViewsOptions): void {
+export function usePageViews({ gaMeasurementId, enableHashChange }: usePageViewsOptions = {}): void {
   const router = useRouter();
 
   useEffect(() => {

--- a/src/hooks/usePageViews.ts
+++ b/src/hooks/usePageViews.ts
@@ -2,7 +2,12 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { pageView } from "../interactions";
 
-export function usePageViews(gaMeasurementId?: string): void {
+interface usePageViewsOptions {
+  gaMeasurementId?: string;
+  enableHashChange?: boolean;
+}
+
+export function usePageViews({ gaMeasurementId, enableHashChange }: usePageViewsOptions): void {
   const router = useRouter();
 
   useEffect(() => {
@@ -14,11 +19,17 @@ export function usePageViews(gaMeasurementId?: string): void {
     };
 
     router.events.on("routeChangeComplete", handleRouteChange);
-    router.events.on('hashChangeComplete', handleRouteChange);
+    
+    if (enableHashChange) {
+      router.events.on('hashChangeComplete', handleRouteChange);
+    }
 
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);
-      router.events.off('hashChangeComplete', handleRouteChange);
+
+      if (enableHashChange) {
+        router.events.off('hashChangeComplete', handleRouteChange);
+      }
     };
-  }, [router.events]);
+  }, [router.events, gaMeasurementId, enableHashChange]);
 }

--- a/src/hooks/usePagesViews.ts
+++ b/src/hooks/usePagesViews.ts
@@ -1,9 +1,9 @@
-import { usePageViews, usePageViewsOptions } from "./usePageViews";
+import { usePageViews, UsePageViewsOptions } from "./usePageViews";
 
 /**
  *
  * @deprecated Use usePageViews instead
  */
-export function usePagesViews(options?: usePageViewsOptions): void {
+export function usePagesViews(options?: UsePageViewsOptions): void {
   usePageViews(options);
 }

--- a/src/hooks/usePagesViews.ts
+++ b/src/hooks/usePagesViews.ts
@@ -1,9 +1,9 @@
-import { usePageViews } from "./usePageViews";
+import { usePageViews, usePageViewsOptions } from "./usePageViews";
 
 /**
  *
  * @deprecated Use usePageViews instead
  */
-export function usePagesViews(gaMeasurementId?: string): void {
-  usePageViews(gaMeasurementId);
+export function usePagesViews(options?: usePageViewsOptions): void {
+  usePageViews(options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { GoogleAnalytics } from "./components";
-export { usePagesViews, usePageViews } from "./hooks";
+export { usePagesViews, usePageViews, UsePageViewsOptions } from "./hooks";
 export { pageView, event } from "./interactions";


### PR DESCRIPTION
This would allow us to handle hash changes as page views.

This is what [Next.js example code](https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/pages/_app.js#L12-L16) does. And based on the [router docs](https://nextjs.org/docs/api-reference/next/router#:~:text=not%20the%20page-,hashChangeComplete,-(url%2C%20%7B%20shallow%20%7D)) we may consider a hash change a URL change.

Optionally we could leave this feature behind a flag if needed