### PR TITLE
Allow users to send other options to events

### DIFF
--- a/src/interactions/event.ts
+++ b/src/interactions/event.ts
@@ -1,12 +1,13 @@
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
 
-type EventOptions = {
+// eslint-disable-next-line no-explicit-any
+type EventOptions = Record<string, any> & {
   category?: string;
   label?: string;
   value?: number;
   nonInteraction?: boolean;
   userId?: string;
-} & Record<string, any>;
+};
 
 export function event(
   action: string,
@@ -20,13 +21,14 @@ export function event(
     return;
   }
 
-  const eventOptions: {
+  // eslint-disable-next-line no-explicit-any
+  const eventOptions: Record<string, any> & {
     event_category?: string;
     event_label?: string;
     value?: number;
     non_interaction?: boolean;
     user_id?: string;
-  } & Record<string, any> = { ...otherOptions };
+  } = { ...otherOptions };
 
   if (category !== undefined) {
     eventOptions.event_category = category;

--- a/src/interactions/event.ts
+++ b/src/interactions/event.ts
@@ -1,6 +1,6 @@
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
 
-// eslint-disable-next-line no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type EventOptions = Record<string, any> & {
   category?: string;
   label?: string;
@@ -21,7 +21,7 @@ export function event(
     return;
   }
 
-  // eslint-disable-next-line no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const eventOptions: Record<string, any> & {
     event_category?: string;
     event_label?: string;

--- a/src/interactions/event.ts
+++ b/src/interactions/event.ts
@@ -6,11 +6,11 @@ type EventOptions = {
   value?: number;
   nonInteraction?: boolean;
   userId?: string;
-};
+} & Record<string, any>;
 
 export function event(
   action: string,
-  { category, label, value, nonInteraction, userId }: EventOptions = {},
+  { category, label, value, nonInteraction, userId, ...otherOptions }: EventOptions = {},
   gaMeasurementId?: string
 ): void {
   const _gaMeasurementId =
@@ -26,7 +26,7 @@ export function event(
     value?: number;
     non_interaction?: boolean;
     user_id?: string;
-  } = {};
+  } & Record<string, any> = { ...otherOptions };
 
   if (category !== undefined) {
     eventOptions.event_category = category;


### PR DESCRIPTION
Events can take any property as options to get more info on your analytics

As seen in [Google Analytics beta docs](https://developers.google.com/tag-platform/gtagjs/reference/events?hl=en) and the [Google Analytics 4 docs](https://developers.google.com/analytics/devguides/collection/ga4/reference/events)

This leaves the default behaviour as is, but lets user specify more props inside the same object 