### PR TITLE
adding prop to customize path for googletagmanager script

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ const App = ({ Component, pageProps }) => {
 
 export default App;
 ```
+also, you can use alternative to default path for googletagmanager script by
+```js
+<GoogleAnalytics gtagUrl="/gtag.js" />
+```
 
 ## Page views
 

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -4,6 +4,7 @@ import { usePageViews } from "../hooks";
 
 type GoogleAnalyticsProps = {
   gaMeasurementId?: string;
+  gtagUrl?: string;
   strategy?: ScriptProps["strategy"];
 };
 
@@ -19,6 +20,7 @@ type WithIgnoreHashChange = GoogleAnalyticsProps & {
 
 export function GoogleAnalytics({
   gaMeasurementId,
+  gtagUrl = "https://www.googletagmanager.com/gtag/js",
   strategy = "afterInteractive",
   trackPageViews,
 }: WithPageView | WithIgnoreHashChange): JSX.Element | null {
@@ -41,7 +43,7 @@ export function GoogleAnalytics({
   return (
     <>
       <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${_gaMeasurementId}`}
+        src={`${gtagUrl}?id=${_gaMeasurementId}`}
         strategy={strategy}
       />
       <Script id="nextjs-google-analytics">


### PR DESCRIPTION
Hi and thank you for your great lib
I want to add an ability to use a customized googletabmanager script so it can be modified and optimized to bypass ad-blockers

I am a writer on Medium and if you approve this request I will cover the above solution in my next article with credits to your work
https://medium.vladmykol.com/