### PR TITLE
Fix for Next 13: Use the singleton Router for events

### DIFF
--- a/src/components/GoogleAnalytics.test.tsx
+++ b/src/components/GoogleAnalytics.test.tsx
@@ -1,19 +1,17 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { GoogleAnalytics } from "./GoogleAnalytics";
+import { Router } from "next/router";
 import * as hooks from "../hooks";
 
-const mockEventOn = jest.fn();
 jest.mock("next/router", () => {
   return {
     ...jest.requireActual("next/router"),
-    useRouter: () => {
-      return {
-        events: {
-          on: mockEventOn,
-          off: () => null,
-        },
-      };
+    Router: {
+      events: {
+        on: jest.fn(),
+        off: () => null,
+      },
     },
   };
 });
@@ -32,7 +30,7 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: undefined,
       ignoreHashChange: false,
     });
-    expect(mockEventOn).not.toBeCalled();
+    expect(Router.events.on).not.toBeCalled();
   });
 
   it("should disable usePageViews if trackPageViews is set to false", () => {
@@ -42,7 +40,7 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: undefined,
       ignoreHashChange: false,
     });
-    expect(mockEventOn).not.toBeCalled();
+    expect(Router.events.on).not.toBeCalled();
   });
 
   it("should call usePageViews with gaMeasurementId", () => {
@@ -52,7 +50,7 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: "1234",
       ignoreHashChange: false,
     });
-    expect(mockEventOn).not.toBeCalled();
+    expect(Router.events.on).not.toBeCalled();
   });
 
   it("should enable usePageViews if trackPageViews is set", () => {
@@ -62,7 +60,7 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: undefined,
       ignoreHashChange: false,
     });
-    expect(mockEventOn).toBeCalled();
+    expect(Router.events.on).toBeCalled();
   });
 
   it("should enable usePageViews and ignoreHashChange", () => {
@@ -72,7 +70,7 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: undefined,
       ignoreHashChange: true,
     });
-    expect(mockEventOn).toBeCalled();
+    expect(Router.events.on).toBeCalled();
   });
 
   it("should enable usePageViews and ignoreHashChange with gaMeasurementId", () => {
@@ -87,7 +85,7 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: "1234",
       ignoreHashChange: false,
     });
-    expect(mockEventOn).toBeCalled();
+    expect(Router.events.on).toBeCalled();
   });
 
   it("should enable usePageViews and ignoreHashChange with gaMeasurementId from env", () => {
@@ -98,7 +96,7 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: "1234",
       ignoreHashChange: false,
     });
-    expect(mockEventOn).toBeCalled();
+    expect(Router.events.on).toBeCalled();
   });
 
   it("should override param if env is used", () => {
@@ -114,6 +112,6 @@ describe("GoogleAnalytics", () => {
       gaMeasurementId: "1234",
       ignoreHashChange: false,
     });
-    expect(mockEventOn).toBeCalled();
+    expect(Router.events.on).toBeCalled();
   });
 });

--- a/src/hooks/usePageViews.ts
+++ b/src/hooks/usePageViews.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useRouter } from "next/router";
+import { Router } from "next/router";
 import { pageView } from "../interactions";
 
 export interface UsePageViewsOptions {
@@ -13,8 +13,6 @@ export function usePageViews({
   ignoreHashChange,
   disabled,
 }: UsePageViewsOptions = {}): void {
-  const router = useRouter();
-
   useEffect(() => {
     if (disabled) {
       return;
@@ -27,18 +25,18 @@ export function usePageViews({
       pageView({ path: url.toString() }, _gaMeasurementId);
     };
 
-    router.events.on("routeChangeComplete", handleRouteChange);
+    Router.events.on("routeChangeComplete", handleRouteChange);
 
     if (!ignoreHashChange) {
-      router.events.on("hashChangeComplete", handleRouteChange);
+      Router.events.on("hashChangeComplete", handleRouteChange);
     }
 
     return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
+      Router.events.off("routeChangeComplete", handleRouteChange);
 
       if (!ignoreHashChange) {
-        router.events.off("hashChangeComplete", handleRouteChange);
+        Router.events.off("hashChangeComplete", handleRouteChange);
       }
     };
-  }, [router.events, gaMeasurementId, ignoreHashChange]);
+  }, [Router.events, gaMeasurementId, ignoreHashChange]);
 }


### PR DESCRIPTION
The library doesn't currently work with Next 13 (using the `app` directory), giving an error that `router.events` is null.

Router events are a [static property on the singleton Router](https://github.com/vercel/next.js/blob/canary/packages/next/client/router.ts#L67-L72), which are accessed directly by the routers created with `useRouter()`.  

With the changes in Next 13, the `useRouter()` events no longer work, however the `Router.events` property is still accessible.

This is a minor change that seems to solve the problems with Next 13's `app` directory.  (FYI, I understand the `/app` directory is still beta/experimental, so I fully understand if you want to close this PR, though it should be safe to include regardless).