### PR TITLE
add support for debug_mode

### DIFF
--- a/src/components/GoogleAnalytics.test.tsx
+++ b/src/components/GoogleAnalytics.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { GoogleAnalytics } from "./GoogleAnalytics";
 import { Router } from "next/router";
 import * as hooks from "../hooks";
@@ -15,6 +15,14 @@ jest.mock("next/router", () => {
     },
   };
 });
+
+jest.mock(
+  "next/script",
+  () =>
+    function MockScript(props: any) {
+      return <div {...props} />;
+    }
+);
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -113,5 +121,15 @@ describe("GoogleAnalytics", () => {
       ignoreHashChange: false,
     });
     expect(Router.events.on).toBeCalled();
+  });
+
+  it("should default to a debug_mode of false", () => {
+    render(<GoogleAnalytics gaMeasurementId="1234" />);
+    expect(screen.queryByText(/debug_mode: false/)).not.toBeNull();
+  });
+
+  it("should have a debug_mode of true when the debugMode prop is set", () => {
+    render(<GoogleAnalytics gaMeasurementId="1234" debugMode />);
+    expect(screen.queryByText(/debug_mode: true/)).not.toBeNull();
   });
 });

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -6,6 +6,7 @@ type GoogleAnalyticsProps = {
   gaMeasurementId?: string;
   gtagUrl?: string;
   strategy?: ScriptProps["strategy"];
+  debugMode?: boolean;
 };
 
 type WithPageView = GoogleAnalyticsProps & {
@@ -19,6 +20,7 @@ type WithIgnoreHashChange = GoogleAnalyticsProps & {
 };
 
 export function GoogleAnalytics({
+  debugMode = false,
   gaMeasurementId,
   gtagUrl = "https://www.googletagmanager.com/gtag/js",
   strategy = "afterInteractive",
@@ -42,10 +44,7 @@ export function GoogleAnalytics({
 
   return (
     <>
-      <Script
-        src={`${gtagUrl}?id=${_gaMeasurementId}`}
-        strategy={strategy}
-      />
+      <Script src={`${gtagUrl}?id=${_gaMeasurementId}`} strategy={strategy} />
       <Script id="nextjs-google-analytics">
         {`
             window.dataLayer = window.dataLayer || [];
@@ -53,6 +52,7 @@ export function GoogleAnalytics({
             gtag('js', new Date());
             gtag('config', '${_gaMeasurementId}', {
               page_path: window.location.pathname,
+              debug_mode: ${debugMode},
             });
           `}
       </Script>


### PR DESCRIPTION
Adds the ability to enable [debug mode](https://support.google.com/analytics/answer/7201382#zippy=%2Cgoogle-tag-websites) via a prop on `GoogleAnalytics`.