### PR TITLE
Expose Consent API

### DIFF
--- a/src/components/GoogleAnalytics.test.tsx
+++ b/src/components/GoogleAnalytics.test.tsx
@@ -134,4 +134,22 @@ describe("GoogleAnalytics", () => {
       expect(screen.queryByText(/debug_mode:/)).not.toBeNull();
     });
   });
+
+  describe("defaultConsent", () => {
+    it("should have consent explicitly denied when defaultConsent is set to 'denied'", () => {
+      render(<GoogleAnalytics gaMeasurementId="1234" defaultConsent="denied" />);
+      expect(screen.queryByText(/'ad_storage': 'denied'/)).not.toBeNull();
+      expect(screen.queryByText(/'analytics_storage': 'denied'/)).not.toBeNull();
+    });
+
+    it("should not call consent function at all when defaultConsent is set to 'granted'", () => {
+      render(<GoogleAnalytics gaMeasurementId="1234" defaultConsent="granted" />);
+      expect(screen.queryByText(/'consent', 'default'/)).toBeNull();
+    });
+
+    it("should not call consent function at all when defaultConsent is omitted", () => {
+      render(<GoogleAnalytics gaMeasurementId="1234" />);
+      expect(screen.queryByText(/'consent', 'default'/)).toBeNull();
+    });
+  });
 });

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -7,6 +7,7 @@ type GoogleAnalyticsProps = {
   gtagUrl?: string;
   strategy?: ScriptProps["strategy"];
   debugMode?: boolean;
+  defaultConsent?: "granted" | "denied";
 };
 
 type WithPageView = GoogleAnalyticsProps & {
@@ -24,6 +25,7 @@ export function GoogleAnalytics({
   gaMeasurementId,
   gtagUrl = "https://www.googletagmanager.com/gtag/js",
   strategy = "afterInteractive",
+  defaultConsent = "granted",
   trackPageViews,
 }: WithPageView | WithIgnoreHashChange): JSX.Element | null {
   const _gaMeasurementId =
@@ -50,6 +52,10 @@ export function GoogleAnalytics({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
+            ${defaultConsent === "denied" && `gtag('consent', 'default', {
+              'ad_storage': 'denied',
+              'analytics_storage': 'denied'
+            });`}
             gtag('config', '${_gaMeasurementId}', {
               page_path: window.location.pathname,
               ${debugMode ? `debug_mode: ${debugMode},` : ""}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { GoogleAnalytics } from "./components";
 export { usePagesViews, usePageViews, UsePageViewsOptions } from "./hooks";
-export { pageView, event } from "./interactions";
+export { pageView, event, consent } from "./interactions";

--- a/src/interactions/consent.test.ts
+++ b/src/interactions/consent.test.ts
@@ -1,0 +1,19 @@
+import { consent } from './consent'
+
+const mockArg: Gtag.ConsentArg = 'default'
+const mockParams: Gtag.ConsentParams = { ad_storage: 'denied', analytics_storage: 'denied' }
+
+describe("consent", () => {
+  it("should not throw an error if gtag is not defined", () => {
+    const action = () => consent({ arg: 'default', params: {} });
+    expect(action).not.toThrow();
+  });
+
+  it("should call gtag with all the options", () => {
+    window.gtag = jest.fn();
+    consent({ arg: mockArg, params: mockParams });
+    expect(window.gtag).toBeCalledTimes(1);
+    expect(window.gtag).toBeCalledWith('consent', mockArg, mockParams);
+  });
+})
+

--- a/src/interactions/consent.ts
+++ b/src/interactions/consent.ts
@@ -1,0 +1,13 @@
+// https://developers.google.com/tag-platform/devguides/consent#gtag.js
+
+type ConsentOptions = {
+  arg: Gtag.ConsentArg;
+  params: Gtag.ConsentParams;
+}
+
+export function consent({ arg, params }: ConsentOptions): void {
+  if (!window.gtag) {
+    return;
+  }
+  window.gtag('consent', arg, params);
+}

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -1,2 +1,3 @@
 export { pageView } from "./pageView";
 export { event } from "./event";
+export { consent } from "./consent";


### PR DESCRIPTION
Expose consent function from `gtag.js` and allow to initialize GA with `denied` consent (defaults to `granted` if omitted).

https://developers.google.com/tag-platform/devguides/consent#gtag.js