### PR TITLE
feat(script-element): html script to head, next/script for body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-google-analytics",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Google Analytics for Next.js",
   "main": "dist/index.js",
   "sideEffects": false,

--- a/src/components/GoogleAnalytics.test.tsx
+++ b/src/components/GoogleAnalytics.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { GoogleAnalytics } from "./GoogleAnalytics";
+import {
+  BodyScriptGoogleAnalytics,
+  GoogleAnalytics,
+  HeadScriptGoogleAnalytics,
+} from "./GoogleAnalytics";
 import { Router } from "next/router";
 import * as hooks from "../hooks";
 
@@ -30,126 +34,176 @@ afterEach(() => {
 
 describe("GoogleAnalytics", () => {
   const usePageViewsSpy = jest.spyOn(hooks, "usePageViews");
+  const testableComponents = [
+    GoogleAnalytics,
+    BodyScriptGoogleAnalytics,
+    HeadScriptGoogleAnalytics,
+  ] as const;
 
-  it("should disable usePageViews if trackPageViews not set", () => {
-    render(<GoogleAnalytics />);
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: true,
-      gaMeasurementId: undefined,
-      ignoreHashChange: false,
-    });
-    expect(Router.events.on).not.toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should disable usePageViews if trackPageViews not set",
+    (GoogleAnalytics) => {
+      render(<GoogleAnalytics />);
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: true,
+        gaMeasurementId: undefined,
+        ignoreHashChange: false,
+      });
+      expect(Router.events.on).not.toBeCalled();
+    }
+  );
 
-  it("should disable usePageViews if trackPageViews is set to false", () => {
-    render(<GoogleAnalytics trackPageViews={false} />);
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: true,
-      gaMeasurementId: undefined,
-      ignoreHashChange: false,
-    });
-    expect(Router.events.on).not.toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should disable usePageViews if trackPageViews is set to false",
+    (GoogleAnalytics) => {
+      render(<GoogleAnalytics trackPageViews={false} />);
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: true,
+        gaMeasurementId: undefined,
+        ignoreHashChange: false,
+      });
+      expect(Router.events.on).not.toBeCalled();
+    }
+  );
 
-  it("should call usePageViews with gaMeasurementId", () => {
-    render(<GoogleAnalytics gaMeasurementId="1234" />);
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: true,
-      gaMeasurementId: "1234",
-      ignoreHashChange: false,
-    });
-    expect(Router.events.on).not.toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should call usePageViews with gaMeasurementId",
+    (GoogleAnalytics) => {
+      render(<GoogleAnalytics gaMeasurementId="1234" />);
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: true,
+        gaMeasurementId: "1234",
+        ignoreHashChange: false,
+      });
+      expect(Router.events.on).not.toBeCalled();
+    }
+  );
 
-  it("should enable usePageViews if trackPageViews is set", () => {
-    render(<GoogleAnalytics trackPageViews />);
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: false,
-      gaMeasurementId: undefined,
-      ignoreHashChange: false,
-    });
-    expect(Router.events.on).toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should enable usePageViews if trackPageViews is set",
+    (GoogleAnalytics) => {
+      render(<GoogleAnalytics trackPageViews />);
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: false,
+        gaMeasurementId: undefined,
+        ignoreHashChange: false,
+      });
+      expect(Router.events.on).toBeCalled();
+    }
+  );
 
-  it("should enable usePageViews and ignoreHashChange", () => {
-    render(<GoogleAnalytics trackPageViews={{ ignoreHashChange: true }} />);
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: false,
-      gaMeasurementId: undefined,
-      ignoreHashChange: true,
-    });
-    expect(Router.events.on).toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should enable usePageViews and ignoreHashChange",
+    (GoogleAnalytics) => {
+      render(<GoogleAnalytics trackPageViews={{ ignoreHashChange: true }} />);
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: false,
+        gaMeasurementId: undefined,
+        ignoreHashChange: true,
+      });
+      expect(Router.events.on).toBeCalled();
+    }
+  );
 
-  it("should enable usePageViews and ignoreHashChange with gaMeasurementId", () => {
-    render(
-      <GoogleAnalytics
-        trackPageViews={{ ignoreHashChange: false }}
-        gaMeasurementId="1234"
-      />
-    );
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: false,
-      gaMeasurementId: "1234",
-      ignoreHashChange: false,
-    });
-    expect(Router.events.on).toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should enable usePageViews and ignoreHashChange with gaMeasurementId",
+    (GoogleAnalytics) => {
+      render(
+        <GoogleAnalytics
+          trackPageViews={{ ignoreHashChange: false }}
+          gaMeasurementId="1234"
+        />
+      );
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: false,
+        gaMeasurementId: "1234",
+        ignoreHashChange: false,
+      });
+      expect(Router.events.on).toBeCalled();
+    }
+  );
 
-  it("should enable usePageViews and ignoreHashChange with gaMeasurementId from env", () => {
-    process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = "1234";
-    render(<GoogleAnalytics trackPageViews={{ ignoreHashChange: false }} />);
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: false,
-      gaMeasurementId: "1234",
-      ignoreHashChange: false,
-    });
-    expect(Router.events.on).toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should enable usePageViews and ignoreHashChange with gaMeasurementId from env",
+    (GoogleAnalytics) => {
+      process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = "1234";
+      render(<GoogleAnalytics trackPageViews={{ ignoreHashChange: false }} />);
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: false,
+        gaMeasurementId: "1234",
+        ignoreHashChange: false,
+      });
+      expect(Router.events.on).toBeCalled();
+    }
+  );
 
-  it("should override param if env is used", () => {
-    process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = "1234";
-    render(
-      <GoogleAnalytics
-        trackPageViews={{ ignoreHashChange: false }}
-        gaMeasurementId="5678"
-      />
-    );
-    expect(usePageViewsSpy).toBeCalledWith({
-      disabled: false,
-      gaMeasurementId: "1234",
-      ignoreHashChange: false,
-    });
-    expect(Router.events.on).toBeCalled();
-  });
+  it.each(testableComponents)(
+    "should override param if env is used",
+    (GoogleAnalytics) => {
+      process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = "1234";
+      render(
+        <GoogleAnalytics
+          trackPageViews={{ ignoreHashChange: false }}
+          gaMeasurementId="5678"
+        />
+      );
+      expect(usePageViewsSpy).toBeCalledWith({
+        disabled: false,
+        gaMeasurementId: "1234",
+        ignoreHashChange: false,
+      });
+      expect(Router.events.on).toBeCalled();
+    }
+  );
 
   describe("debugMode", () => {
-    it("should not have debug_mode when the debugMode prop is not set", () => {
-      render(<GoogleAnalytics gaMeasurementId="1234" />);
-      expect(screen.queryByText(/debug_mode:/)).toBeNull();
-    });
+    it.each(testableComponents)(
+      "should not have debug_mode when the debugMode prop is not set",
+      (GoogleAnalytics) => {
+        render(<GoogleAnalytics gaMeasurementId="1234" />);
+        expect(screen.queryByText(/debug_mode:/)).toBeNull();
+      }
+    );
 
-    it("should have a debug_mode when the debugMode prop is set", () => {
-      render(<GoogleAnalytics gaMeasurementId="1234" debugMode />);
-      expect(screen.queryByText(/debug_mode:/)).not.toBeNull();
-    });
+    it.each(testableComponents)(
+      "should have a debug_mode when the debugMode prop is set",
+      (GoogleAnalytics) => {
+        render(<GoogleAnalytics gaMeasurementId="1234" debugMode />);
+        expect(screen.queryByText(/debug_mode:/)).not.toBeNull();
+      }
+    );
   });
 
   describe("defaultConsent", () => {
-    it("should have consent explicitly denied when defaultConsent is set to 'denied'", () => {
-      render(<GoogleAnalytics gaMeasurementId="1234" defaultConsent="denied" />);
-      expect(screen.queryByText(/'ad_storage': 'denied'/)).not.toBeNull();
-      expect(screen.queryByText(/'analytics_storage': 'denied'/)).not.toBeNull();
-    });
+    it.each(testableComponents)(
+      "should have consent explicitly denied when defaultConsent is set to 'denied'",
+      (GoogleAnalytics) => {
+        render(
+          <GoogleAnalytics gaMeasurementId="1234" defaultConsent="denied" />
+        );
+        expect(screen.queryByText(/'ad_storage': 'denied'/)).not.toBeNull();
+        expect(
+          screen.queryByText(/'analytics_storage': 'denied'/)
+        ).not.toBeNull();
+      }
+    );
 
-    it("should not call consent function at all when defaultConsent is set to 'granted'", () => {
-      render(<GoogleAnalytics gaMeasurementId="1234" defaultConsent="granted" />);
-      expect(screen.queryByText(/'consent', 'default'/)).toBeNull();
-    });
+    it.each(testableComponents)(
+      "should not call consent function at all when defaultConsent is set to 'granted'",
+      (GoogleAnalytics) => {
+        render(
+          <GoogleAnalytics gaMeasurementId="1234" defaultConsent="granted" />
+        );
+        expect(screen.queryByText(/'consent', 'default'/)).toBeNull();
+      }
+    );
 
-    it("should not call consent function at all when defaultConsent is omitted", () => {
-      render(<GoogleAnalytics gaMeasurementId="1234" />);
-      expect(screen.queryByText(/'consent', 'default'/)).toBeNull();
-    });
+    it.each(testableComponents)(
+      "should not call consent function at all when defaultConsent is omitted",
+      (GoogleAnalytics) => {
+        render(<GoogleAnalytics gaMeasurementId="1234" />);
+        expect(screen.queryByText(/'consent', 'default'/)).toBeNull();
+      }
+    );
   });
 });

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -20,14 +20,14 @@ type WithIgnoreHashChange = GoogleAnalyticsProps & {
   };
 };
 
-export function GoogleAnalytics({
+export const BodyScriptGoogleAnalytics = ({
   debugMode = false,
   gaMeasurementId,
   gtagUrl = "https://www.googletagmanager.com/gtag/js",
   strategy = "afterInteractive",
   defaultConsent = "granted",
   trackPageViews,
-}: WithPageView | WithIgnoreHashChange): JSX.Element | null {
+}: WithPageView | WithIgnoreHashChange) => {
   const _gaMeasurementId =
     process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? gaMeasurementId;
 
@@ -52,10 +52,13 @@ export function GoogleAnalytics({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            ${defaultConsent === "denied" && `gtag('consent', 'default', {
+            ${
+              defaultConsent === "denied" &&
+              `gtag('consent', 'default', {
               'ad_storage': 'denied',
               'analytics_storage': 'denied'
-            });`}
+            });`
+            }
             gtag('config', '${_gaMeasurementId}', {
               page_path: window.location.pathname,
               ${debugMode ? `debug_mode: ${debugMode},` : ""}
@@ -64,4 +67,67 @@ export function GoogleAnalytics({
       </Script>
     </>
   );
-}
+};
+
+export const HeadScriptGoogleAnalytics = ({
+  debugMode = false,
+  gaMeasurementId,
+  gtagUrl = "https://www.googletagmanager.com/gtag/js",
+  defaultConsent = "granted",
+  strategy = "none",
+  trackPageViews,
+}: Omit<WithPageView | WithIgnoreHashChange, "strategy"> & {
+  strategy?: "async" | "defer" | "none";
+}) => {
+  const _gaMeasurementId =
+    process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? gaMeasurementId;
+
+  usePageViews({
+    gaMeasurementId: _gaMeasurementId,
+    ignoreHashChange:
+      typeof trackPageViews === "object"
+        ? trackPageViews?.ignoreHashChange
+        : false,
+    disabled: !trackPageViews,
+  });
+
+  if (!_gaMeasurementId) {
+    return null;
+  }
+
+  // react-testing-library ignored `script`, this is only to assert there is element being showed up
+  const Component = process.env.NODE_ENV === "test" ? Script : () => <script />;
+
+  return (
+    <>
+      <Component
+        src={`${gtagUrl}?id=${_gaMeasurementId}`}
+        async={strategy === "async"}
+        defer={strategy === "defer"}
+      />
+      <Component id="nextjs-google-analytics">
+        {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            ${
+              defaultConsent === "denied" &&
+              `gtag('consent', 'default', {
+              'ad_storage': 'denied',
+              'analytics_storage': 'denied'
+            });`
+            }
+            gtag('config', '${_gaMeasurementId}', {
+              page_path: window.location.pathname,
+              ${debugMode ? `debug_mode: ${debugMode},` : ""}
+            });
+          `}
+      </Component>
+    </>
+  );
+};
+
+/**
+ * @deprecated this component is deprecated in favor of `BodyScriptGoogleAnalytics`. For more info visit https://github.com/MauricioRobayo/nextjs-google-analytics/issues/383
+ */
+export const GoogleAnalytics = BodyScriptGoogleAnalytics;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,5 @@
-export { GoogleAnalytics } from "./GoogleAnalytics";
+export {
+  GoogleAnalytics,
+  BodyScriptGoogleAnalytics,
+  HeadScriptGoogleAnalytics,
+} from "./GoogleAnalytics";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
-export { GoogleAnalytics } from "./components";
+export {
+  GoogleAnalytics,
+  HeadScriptGoogleAnalytics,
+  BodyScriptGoogleAnalytics,
+} from "./components";
 export { usePagesViews, usePageViews, UsePageViewsOptions } from "./hooks";
 export { pageView, event, consent } from "./interactions";


### PR DESCRIPTION
The tests has some problem as `react-testing-library` ignored `script` by default and I don't know how to resolve it except having a workaround for `script` works, maybe you know how to fix it