### PR TITLE
fix: prevent 'false' from being inserted into GA tag

### DIFF
--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -55,11 +55,11 @@ export function GoogleAnalytics({
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             ${
-              defaultConsent === "denied" &&
+              defaultConsent === "denied" ?
               `gtag('consent', 'default', {
               'ad_storage': 'denied',
               'analytics_storage': 'denied'
-            });`
+            });` : ``
             }
             gtag('config', '${_gaMeasurementId}', {
               page_path: window.location.pathname,


### PR DESCRIPTION
# Changes

Currently the 'false' string is interpolated into the GA tag, when `defaultConsent` prop is omitted or explicitly set to "granted". Doesn't look like the tag functionality is affected, but seemed like it would be a good idea to clean this up. 

Using a ternary operator to display an empty string instead of (&&) resolves this.

![Screenshot 2023-04-04 at 11 54 39](https://user-images.githubusercontent.com/1645773/229686192-64fe29b1-df68-4bee-970e-be63ede79b44.png)


