### PR TITLE
chore(docs): Add note for Google tag API commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ export function Contact() {
 
 For the possible parameters that can be specified in the `event`, please refer to the `event` command in the Google tag API reference.
 
-- [Google tag API reference](https://developers.google.com/tag-platform/gtagjs/reference#event)
+- [Google tag API reference - event](https://developers.google.com/tag-platform/gtagjs/reference#event)
 
 ## Consent
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ export function Contact() {
 }
 ```
 
+For the possible parameters that can be specified in the `event`, please refer to the `event` command in the Google tag API reference.
+
+- [Google tag API reference](https://developers.google.com/tag-platform/gtagjs/reference#event)
+
 ## Consent
 
 You can use the `consent` function to update your users' cookie preferences (GDPR).
@@ -219,6 +223,10 @@ You can use the `consent` function to update your users' cookie preferences (GDP
     },
  });
 ```
+
+For the possible values that can be specified in `arg` and `params`, please refer to the `consent` command in the Google tag API reference.
+
+- [Google tag API reference - consent](https://developers.google.com/tag-platform/gtagjs/reference#consent)
 
 ## Web Vitals
 


### PR DESCRIPTION
I felt that there was insufficient information about the usage of the `event` and `consent` functions, so I have added additional details to the README.

